### PR TITLE
Added support for exporting with Clone Hero's enhanced open tag

### DIFF
--- a/src/midi.c
+++ b/src/midi.c
@@ -1146,15 +1146,23 @@ int eof_export_midi(EOF_SONG * sp, char * fn, char featurerestriction, char fixv
 						{	//If the open note has crazy status though
 							marker_length = 1;	//End the marker immediately to better suit Clone Hero's MIDI logic to ensure overlapped notes aren't converted to open strums
 						}
-						eof_add_midi_event(deltapos, 0x90, midi_note_offset + 0, vel, 0);	//Write a gem for lane 1
-						eof_add_midi_event(deltapos + deltalength, 0x80, midi_note_offset + 0, vel, 0);
-						phase_shift_sysex_phrase[3] = 0;	//Store the Sysex message ID (0 = phrase marker)
-						phase_shift_sysex_phrase[4] = type;	//Store the difficulty ID (0 = Easy, 1 = Medium, 2 = Hard, 3 = Expert)
-						phase_shift_sysex_phrase[5] = 1;	//Store the phrase ID (1 = Open Strum Bass)
-						phase_shift_sysex_phrase[6] = 1;	//Store the phrase status (1 = Phrase start)
-						eof_add_sysex_event(deltapos, 8, phase_shift_sysex_phrase, 1);	//Write the custom open bass phrase start marker
-						phase_shift_sysex_phrase[6] = 0;	//Store the phrase status (0 = Phrase stop)
-						eof_add_sysex_event(deltapos + marker_length, 8, phase_shift_sysex_phrase, 0);	//Write the custom open bass phrase stop marker
+						if(eof_song_contains_event(sp, "[ENHANCED_OPENS]", j, 0, 1))
+						{	//If the current track has the enhanced opens modifier, write it as a normal note
+							eof_add_midi_event(deltapos, 0x90, midi_note_offset - 1, vel, 0);
+							eof_add_midi_event(deltapos + deltalength, 0x80, midi_note_offset - 1, vel, 0);
+						}
+						else
+						{	//Otherwise write a sysex open note
+							eof_add_midi_event(deltapos, 0x90, midi_note_offset + 0, vel, 0);	//Write a gem for lane 1
+							eof_add_midi_event(deltapos + deltalength, 0x80, midi_note_offset + 0, vel, 0);
+							phase_shift_sysex_phrase[3] = 0;	//Store the Sysex message ID (0 = phrase marker)
+							phase_shift_sysex_phrase[4] = type;	//Store the difficulty ID (0 = Easy, 1 = Medium, 2 = Hard, 3 = Expert)
+							phase_shift_sysex_phrase[5] = 1;	//Store the phrase ID (1 = Open Strum Bass)
+							phase_shift_sysex_phrase[6] = 1;	//Store the phrase status (1 = Phrase start)
+							eof_add_sysex_event(deltapos, 8, phase_shift_sysex_phrase, 1);	//Write the custom open bass phrase start marker
+							phase_shift_sysex_phrase[6] = 0;	//Store the phrase status (0 = Phrase stop)
+							eof_add_sysex_event(deltapos + marker_length, 8, phase_shift_sysex_phrase, 0);	//Write the custom open bass phrase stop marker
+						}
 					}
 				}
 


### PR DESCRIPTION
At some point in the past, Clone Hero added support for a feature called "enhanced opens". When a track contains a local text event at the beginning with the text `[ENHANCED_OPENS]`, it will treat the midi notes immediately below green as open notes. This is different from the standard sysex-based implementation of open notes, which uses sysex events to mark specific notes as being open notes.

Currently, EOF does not support enhanced opens, and will ignore the tag if present and write all open notes as a green note with a sysex event. This can result in undesired behavior with extended sustains, as pointed  out in issue #320, as EOF will overwrite any green notes that overlap with an open sustain since it considers them to both be green notes. With enhanced opens, both notes can be stored independently of each other, allowing for the combination of extended open note sustains and green notes. While it may not be a very common use case, the fact that EOF does not currently support the combination of green and open extended sustains is a flaw, which can be corrected by implementing support for enhanced opens. Because of this, I decided to implement it on my own, hoping it can be included in the main build eventually.

With this change, during the midi export process, when an open note is encountered, I added a check for whether the track contains the enhanced opens text event. If it does, instead of writing a sysex-style open note, it writes to the midi note one below green for the appropriate difficulty. Currently, there is not check for if the event is at the start of the track, as I'm not sure how exactly to check that specifically, however I do not believe it is that big of a concern, as any case where the event is present but is not at the start of the track is improper use of the event flag, and should be corrected by the charter anyways.

I've tested this implementation with all four difficulties on the guitar, rhythm guitar, bass, and co-op guitar instrument tracks, and they seem to work fully as intended, even with HOPO and slider notes included. I also checked to make sure that Expert+ double bass drum notes weren't affected, and that the inclusion of the text event on one track does not affect notes on another, and both of these cases seem to work as intended as well. I had hoped to also implement support for importing charts with enhanced opens, however that remains too difficult a task for me to figure out at the moment. As a result, I've decided to make a pull request for the current state of the change.

Thank you for your time.