### PR TITLE
add UNICODE checking to ini_import

### DIFF
--- a/src/ini_import.h
+++ b/src/ini_import.h
@@ -69,4 +69,6 @@ char *eof_find_ini_setting_tag(EOF_SONG *sp, unsigned long *index, char *tag);
 	//If found, the setting number is returned through index and the pointer to the character after the equal sign in the INI setting's string is returned
 	//If no such setting was found in the project, NULL is returned
 
+int eof_is_unicode(const char *filename);
+	//If *function is nonzero, the filename is UNICODE
 #endif

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,6 @@
 Unversioned To-Do List
 ----------------------
-[ ]INI import should see if file is unicode before processing.
+[X]INI import should see if file is unicode before processing.
    [ ]Don't think there is a way to do this. Instead we should attempt to import as
       usual and if the artist and title fields are empty, attempt to use unicode.
 [ ]Adjust timing of audio cues so that they peak at the time they are supposed


### PR DESCRIPTION
completes todo

some notes for reviewer

1. the function eof_is_unicode checks for UNICODE-8 BOM(byte order marking) and also checks for non-ascii character.
2. this pr assumes that the program wants to EXCLUDE UTF files
3. the function eof_is_unicode checks works 95% of the time