### PR TITLE
fix: at wfsel in wfsel.c

### DIFF
--- a/src/modules/wfsel.c
+++ b/src/modules/wfsel.c
@@ -44,8 +44,8 @@ NCDFS_FILTER_LIST * ncdfs_filter_list_create(void)
 
 int ncdfs_filter_list_add(NCDFS_FILTER_LIST * lp, char * ext, char * desc, int df)
 {
-	ustrcpy(lp->filter[lp->filters].extension, ext);
-	ustrcpy(lp->filter[lp->filters].description, desc);
+	ustrncpy(lp->filter[lp->filters].extension, ext, sizeof(lp->filter[lp->filters].extension) - 1);
+	ustrncpy(lp->filter[lp->filters].description, desc, sizeof(lp->filter[lp->filters].description) - 1);
 	if(df)
 	{
 		lp->default_filter = lp->filters;
@@ -87,14 +87,14 @@ static int ncd_file_select_allegro_want_all(NCDFS_FILTER_LIST * lp)
 
 		if(lp)
 		{
+			int plen = 0;
 			for(i = 0; i < lp->filters; i++)
 			{
 				if(i > 0)
 				{
-					strcat(pattern, ";");
+					plen += snprintf(pattern + plen, sizeof(pattern) - plen, ";");
 				}
-				strcat(pattern, "*.");
-				strcat(pattern, lp->filter[i].extension);
+				plen += snprintf(pattern + plen, sizeof(pattern) - plen, "*.%s", lp->filter[i].extension);
 			}
 		}
 
@@ -118,7 +118,7 @@ static int ncd_file_select_allegro_want_all(NCDFS_FILTER_LIST * lp)
 			c = al_get_native_file_dialog_count(fcp);
 			if(c > 0)
 			{
-				strcpy(ncdfs_internal_return_path, al_get_native_file_dialog_path(fcp, 0));
+				snprintf(ncdfs_internal_return_path, sizeof(ncdfs_internal_return_path), "%s", al_get_native_file_dialog_path(fcp, 0));
 			}
 			al_destroy_native_file_dialog(fcp);
 			if(c > 0)


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/modules/wfsel.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/modules/wfsel.c:121` |
| **CWE** | CWE-120 |

**Description**: At wfsel.c:121, strcpy() copies the return value of al_get_native_file_dialog_path() into the fixed-size buffer ncdfs_internal_return_path without any length check. If the path returned by the native file dialog exceeds the destination buffer size, a stack or heap buffer overflow occurs, overwriting adjacent memory including return addresses or heap metadata. Similarly, at lines 47-48, ustrcpy() copies file filter extension and description strings into fixed-size fields without bounds checking. An attacker who crafts a project file referencing an extremely long resource path can trigger this overflow when the victim opens the file.

## Changes
- `src/modules/wfsel.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
